### PR TITLE
Remove rfc7540 blacklisted cipher

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1472,7 +1472,8 @@ or referencing TLS options in the [`IngressRoute`](#kind-ingressroute) / [`Ingre
         - CurveP384
       cipherSuites:                                 # [4]
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        - TLS_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       clientAuth:                                   # [5]
         secretNames:                                # [6]
           - secretCA1
@@ -1506,7 +1507,8 @@ or referencing TLS options in the [`IngressRoute`](#kind-ingressroute) / [`Ingre
       sniStrict: true
       cipherSuites:
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        - TLS_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       clientAuth:
         secretNames:
           - secretCA1


### PR DESCRIPTION
I see some discussion in #5578 already but as this combination is actually blacklisted (min version 1.2 but version 1.2 on black list `TLS_RSA_WITH_AES_256_GCM_SHA384 `) I think maybe it should be revisited. I actually came across the issue trying to connect to `helm.traefik.io` via a proxy that doesn't support all ciphers and the connection failed completely.

### What does this PR do?

Removes a TLS configuration that should never happen from docs.


### Motivation

```
❯ curl -svvvv https://helm.traefik.io
*   Trying 3.123.181.162...
* TCP_NODELAY set
* Connected to helm.traefik.io (3.123.181.162) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=helm.traefik.io
*  start date: Jan 30 13:10:45 2021 GMT
*  expire date: Apr 30 13:10:45 2021 GMT
*  subjectAltName: host "helm.traefik.io" matched cert's "helm.traefik.io"
*  issuer: C=US; ST=CA; O=paloalto networks; OU=IT; CN=decrypt.paloaltonetworks.com
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7ffeb200f600)
> GET / HTTP/2
> Host: helm.traefik.io
> User-Agent: curl/7.64.1
> Accept: */*
>
* http2 error: Remote peer returned unexpected data while we expected SETTINGS frame.  Perhaps, peer does not support HTTP/2 properly.
*
```


### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
